### PR TITLE
Sync with the metrics naming in Traceloop

### DIFF
--- a/llm/README.md
+++ b/llm/README.md
@@ -30,8 +30,8 @@ vi config/config.yaml
 The following options are required：
 - `otel.backend.url`：The OTel gRPC address of the agent, for example: http://localhost:4317
 - `otel.service.name`：The Data Collector name, which can be any string you choose.
-- `price.prompt.tokens.per.kilo`：The unit price per thousand prompt tokens.
-- `price.complete.tokens.per.kilo`：The unit price per thousand complete tokens.
+- `*.price.prompt.tokens.per.kilo`：The unit price per thousand prompt tokens.
+- `*.price.complete.tokens.per.kilo`：The unit price per thousand complete tokens.
 
 
 ## Run ODCL

--- a/llm/config/config.yaml
+++ b/llm/config/config.yaml
@@ -4,5 +4,10 @@ instances:
   - otel.backend.url: http://localhost:4317
     otel.service.name: DC1
     otel.service.port: 8000
-    price.prompt.tokens.per.kilo: 0.0
-    price.complete.tokens.per.kilo: 0.0
+    #Only configure the settings of the AI provider you are using
+    watsonx.price.prompt.tokens.per.kilo: 0.0
+    watsonx.price.complete.tokens.per.kilo: 0.0
+    openai.price.prompt.tokens.per.kilo: 0.0
+    openai.price.complete.tokens.per.kilo: 0.0
+    anthropic.price.prompt.tokens.per.kilo: 0.0
+    anthropic.price.complete.tokens.per.kilo: 0.0

--- a/llm/src/main/java/com/instana/dc/llm/LLMDcUtil.java
+++ b/llm/src/main/java/com/instana/dc/llm/LLMDcUtil.java
@@ -15,8 +15,12 @@ public class LLMDcUtil {
     public static final String DEFAULT_INSTRUMENTATION_SCOPE_VER = "1.0.0";
     public static final String SERVICE_NAME = "service.name";
     public static final String SERVICE_INSTANCE_ID = "service.instance.id";
-    public final static String PRICE_PROMPT_TOKES_PER_KILO = "price.prompt.tokens.per.kilo";
-    public final static String PRICE_COMPLETE_TOKES_PER_KILO = "price.complete.tokens.per.kilo";
+    public final static String WATSONX_PRICE_PROMPT_TOKES_PER_KILO = "watsonx.price.prompt.tokens.per.kilo";
+    public final static String WATSONX_PRICE_COMPLETE_TOKES_PER_KILO = "watsonx.price.complete.tokens.per.kilo";
+    public final static String OPENAI_PRICE_PROMPT_TOKES_PER_KILO = "openai.price.prompt.tokens.per.kilo";
+    public final static String OPENAI_PRICE_COMPLETE_TOKES_PER_KILO = "openai.price.complete.tokens.per.kilo";
+    public final static String ANTHROPIC_PRICE_PROMPT_TOKES_PER_KILO = "anthropic.price.prompt.tokens.per.kilo";
+    public final static String ANTHROPIC_PRICE_COMPLETE_TOKES_PER_KILO = "anthropic.price.complete.tokens.per.kilo";
     public final static String SERVICE_LISTEN_PORT = "otel.service.port";
 
     /* Configurations for Metrics:

--- a/llm/src/main/java/com/instana/dc/llm/impl/llm/MetricsCollectorService.java
+++ b/llm/src/main/java/com/instana/dc/llm/impl/llm/MetricsCollectorService.java
@@ -117,7 +117,9 @@ class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase 
                         switch (metric.getDataCase()) {
                             case SUM:
                                 if (metric.getName().compareTo("llm.watsonx.completions.tokens") == 0 ||
-                                        metric.getName().compareTo("llm.openai.chat_completions.tokens") == 0) {
+                                        metric.getName().compareTo("llm.openai.chat_completions.tokens") == 0 ||
+                                        metric.getName().compareTo("llm.anthropic.completion.tokens") == 0 ||
+                                        metric.getName().compareTo("gen_ai.client.token.usage") == 0) {
 
                                     List<NumberDataPoint> sumDataPoints = metric.getSum().getDataPointsList();
                                     for (NumberDataPoint dataPoint : sumDataPoints) {
@@ -159,7 +161,9 @@ class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase 
                                 break;
                             case HISTOGRAM:
                                 if (metric.getName().compareTo("llm.watsonx.completions.duration") == 0 ||
-                                        metric.getName().compareTo("llm.openai.chat_completions.duration") == 0) {
+                                        metric.getName().compareTo("llm.openai.chat_completions.duration") == 0 ||
+                                        metric.getName().compareTo("llm.anthropic.completion.duration") == 0 ||
+                                        metric.getName().compareTo("gen_ai.client.operation.duration") == 0) {
 
                                     List<HistogramDataPoint> histDataPoints = metric.getHistogram().getDataPointsList();
                                     for (HistogramDataPoint dataPoint : histDataPoints) {

--- a/llm/src/main/java/com/instana/dc/llm/impl/llm/MetricsCollectorService.java
+++ b/llm/src/main/java/com/instana/dc/llm/impl/llm/MetricsCollectorService.java
@@ -173,8 +173,12 @@ class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase 
                                             OtelMetric otelMetric = new OtelMetric();
                                             otelMetric.setModelId(modelId);
                                             otelMetric.setAiSystem(aiSystem);
-                                            otelMetric.setPromptTokens(promptTokens);
-                                            otelMetric.setCompleteTokens(completeTokens);
+                                            if(promptTokens > 0) {
+                                                otelMetric.setPromptTokens(promptTokens);
+                                            }
+                                            if(completeTokens > 0) {
+                                                otelMetric.setCompleteTokens(completeTokens);
+                                            }
                                             exportMetrics.add(otelMetric);
                                         }
                                     }

--- a/llm/src/main/java/com/instana/dc/llm/impl/llm/MetricsCollectorService.java
+++ b/llm/src/main/java/com/instana/dc/llm/impl/llm/MetricsCollectorService.java
@@ -17,8 +17,10 @@ import io.opentelemetry.proto.resource.v1.Resource;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.logging.Logger;
 
 class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase {
+    private static final Logger logger = Logger.getLogger(MetricsCollectorService.class.getName());
 
     private Object mutex = new Object();
 
@@ -28,6 +30,7 @@ class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase 
         private long completeTokens;
         private double duration;
         private long requestCount;
+        private String aiSystem;
 
         public String getModelId() {
             return modelId;
@@ -49,6 +52,10 @@ class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase 
             return requestCount;
         }
 
+        public String getAiSystem() {
+            return aiSystem;
+        }
+
         public void setModelId(String modelId) {
             this.modelId = modelId;
         }
@@ -67,6 +74,10 @@ class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase 
 
         public void setReqCount(long requestCount) {
             this.requestCount = requestCount;
+        }
+
+        public void setAiSystem(String aiSystem) {
+            this.aiSystem = aiSystem;
         }
     }
 
@@ -87,7 +98,7 @@ class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase 
             ExportMetricsServiceRequest request,
             StreamObserver<ExportMetricsServiceResponse> responseObserver) {
 
-        System.out.println("--------------------------------------------------------");
+        logger.info("--------------------------------------------------------");
 
         synchronized (mutex) {
 
@@ -96,23 +107,23 @@ class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase 
 
                 Resource resource = resourceMetrics.getResource();
                 for (KeyValue reskv : resource.getAttributesList()) {
-                    System.out.println("Received metric --- Resource attrKey: " + reskv.getKey());
-                    System.out.println("Received metric --- Resource attrVal: " + reskv.getValue().getStringValue());
+                    logger.info("Received metric --- Resource attrKey: " + reskv.getKey());
+                    logger.info("Received metric --- Resource attrVal: " + reskv.getValue().getStringValue());
                 }
 
                 for (ScopeMetrics scoMetrics : resourceMetrics.getScopeMetricsList()) {
                     InstrumentationScope instrumentationScope = scoMetrics.getScope();
                     instrumentationScope.getAttributesList();
                     for (KeyValue inskv : instrumentationScope.getAttributesList()) {
-                        System.out.println("Received metric --- Scope attrKey: " + inskv.getKey());
-                        System.out.println("Received metric --- Scope attrVal: " + inskv.getValue().getStringValue());
+                        logger.info("Received metric --- Scope attrKey: " + inskv.getKey());
+                        logger.info("Received metric --- Scope attrVal: " + inskv.getValue().getStringValue());
                     }
 
                     for (Metric metric : scoMetrics.getMetricsList()) {
-                        System.out.println("Received metric --- Scope Name: " + metric.getName());
-                        System.out.println("Received metric --- Scope Desc: " + metric.getDescription());
-                        System.out.println("Received metric --- Scope Unit: " + metric.getUnit());
-                        System.out.println("Received metric --- Scope Case: " + metric.getDataCase().getNumber());
+                        logger.info("Received metric --- Scope Name: " + metric.getName());
+                        logger.info("Received metric --- Scope Desc: " + metric.getDescription());
+                        logger.info("Received metric --- Scope Unit: " + metric.getUnit());
+                        logger.info("Received metric --- Scope Case: " + metric.getDataCase().getNumber());
 
                         switch (metric.getDataCase()) {
                             case SUM:
@@ -128,30 +139,40 @@ class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase 
 
                                         String modelId = "";
                                         String tokenType = "";
+                                        String aiSystem = "";
                                         for (KeyValue kv : kvList) {
-                                            System.out.println("Received metric --- Tokens attrKey: " + kv.getKey());
-                                            System.out.println("Received metric --- Tokens attrVal: "
+                                            logger.info("Received metric --- Tokens attrKey: " + kv.getKey());
+                                            logger.info("Received metric --- Tokens attrVal: "
                                                     + kv.getValue().getStringValue());
                                             if (kv.getKey().compareTo("llm.response.model") == 0 || kv.getKey().compareTo("gen_ai.response.model") == 0) {
                                                 modelId = kv.getValue().getStringValue();
-                                            } else if (kv.getKey().compareTo("llm.usage.token_type") == 0) {
+                                            } else if (kv.getKey().compareTo("llm.usage.token_type") == 0 || kv.getKey().compareTo("gen_ai.token.type") == 0) {
                                                 tokenType = kv.getValue().getStringValue();
+                                            } else if (kv.getKey().compareTo("gen_ai.system") == 0) {
+                                                aiSystem = kv.getValue().getStringValue();
                                             }
+                                        }
+                                        if (aiSystem.isEmpty() && metric.getName().compareTo("gen_ai.client.token.usage") != 0) {
+                                            String[] parts = metric.getName().split("\\.", 3);
+                                            aiSystem = parts[1];
+                                        } else {
+                                            aiSystem = "n/a";
                                         }
 
                                         long promptTokens = 0;
                                         long completeTokens = 0;
-                                        if (tokenType.compareTo("prompt") == 0) {
+                                        if (tokenType.compareTo("prompt") == 0 || tokenType.compareTo("input") == 0) {
                                             promptTokens = dataPoint.getAsInt();
-                                            System.out.println("Received metric --- Prompt Value: " + promptTokens);
-                                        } else if (tokenType.compareTo("completion") == 0) {
+                                            logger.info("Received metric --- Prompt Value: " + promptTokens);
+                                        } else if (tokenType.compareTo("completion") == 0 || tokenType.compareTo("output") == 0) {
                                             completeTokens = dataPoint.getAsInt();
-                                            System.out.println("Received metric --- Complete Value: " + completeTokens);
+                                            logger.info("Received metric --- Complete Value: " + completeTokens);
                                         }
 
                                         if (!modelId.isEmpty()) {
                                             OtelMetric otelMetric = new OtelMetric();
                                             otelMetric.setModelId(modelId);
+                                            otelMetric.setAiSystem(aiSystem);
                                             otelMetric.setPromptTokens(promptTokens);
                                             otelMetric.setCompleteTokens(completeTokens);
                                             exportMetrics.add(otelMetric);
@@ -171,23 +192,33 @@ class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase 
                                         List<KeyValue> kvList = dataPoint.getAttributesList();
 
                                         String modelId = "";
+                                        String aiSystem = "";
                                         for (KeyValue kv : kvList) {
-                                            System.out.println("Received metric --- Duration attrKey: " + kv.getKey());
-                                            System.out.println("Received metric --- Duration attrVal: "
+                                            logger.info("Received metric --- Duration attrKey: " + kv.getKey());
+                                            logger.info("Received metric --- Duration attrVal: "
                                                     + kv.getValue().getStringValue());
                                             if (kv.getKey().compareTo("llm.response.model") == 0 || kv.getKey().compareTo("gen_ai.response.model") == 0) {
                                                 modelId = kv.getValue().getStringValue();
+                                            } else if (kv.getKey().compareTo("gen_ai.system") == 0) {
+                                                aiSystem = kv.getValue().getStringValue();
                                             }
+                                        }
+                                        if (aiSystem.isEmpty() && metric.getName().compareTo("gen_ai.client.token.usage") != 0) {
+                                            String[] parts = metric.getName().split("\\.", 3);
+                                            aiSystem = parts[1];
+                                        } else {
+                                            aiSystem = "n/a";
                                         }
 
                                         Double durationSum = dataPoint.getSum();
                                         long requestCount = dataPoint.getCount();
-                                        System.out.println("Received metric --- Duration Sum Value: " + durationSum);
-                                        System.out.println("Received metric --- Duration Count Value: " + requestCount);
+                                        logger.info("Received metric --- Duration Sum Value: " + durationSum);
+                                        logger.info("Received metric --- Duration Count Value: " + requestCount);
 
                                         if (!modelId.isEmpty()) {
                                             OtelMetric otelMetric = new OtelMetric();
                                             otelMetric.setModelId(modelId);
+                                            otelMetric.setAiSystem(aiSystem);
                                             otelMetric.setDuration(durationSum);
                                             otelMetric.setReqCount(requestCount);
                                             exportMetrics.add(otelMetric);
@@ -198,7 +229,7 @@ class MetricsCollectorService extends MetricsServiceGrpc.MetricsServiceImplBase 
                             case GAUGE:
                             case SUMMARY:
                             default:
-                                System.out.println("Unsupported metric DataCase: " + metric.getDataCase());
+                                logger.info("Unsupported metric DataCase: " + metric.getDataCase());
                                 throw new AssertionError("Unsupported metric DataCase: " + metric.getDataCase());
                         }
                     }


### PR DESCRIPTION
In Traceloop, some metrics names have been unified, the DC need to keep sync, but the DC still keep the old metrics name to being compatible with old Traceloop sdk. Currently, the LLM DC need to work with Traceloop-sdk 0.18.2