### PR TITLE
Adding new Semantics for RDB related to Informix DB for release 4

### DIFF
--- a/docs/semconv/database.md
+++ b/docs/semconv/database.md
@@ -40,6 +40,14 @@ This page tries to describe a semantic convention for the attributes and metrics
   - [Metric `db.overflow.lock.count`](#metric-dboverflowlockcount)
   - [Metric `db.overflow.transaction.count`](#metric-dboverflowtransactioncount)
   - [Metric `db.overflow.user.count`](#metric-dboverflowusercount)
+  - [Metric `db.chunk.reads`](#metric-dbchunkreads)
+  - [Metric `db.chunk.writes`](#metric-dbchunkwrites)
+  - [Metric `db.chunk.pages.read`](#metric-dbchunkpagesread)
+  - [Metric `db.chunk.pages.read`](#metric-dbchunkpageswrite)
+  - [Metric `db.memory.segment.size`](#metric-dbmemorysegmentsize)
+  - [Metric `db.memory.segment.bulk.used`](#metric-dbmemorysegmentbulkused)
+  - [Metric `db.memory.segment.bulk.free`](#metric-dbmemorysegmentbulkfree)
+  - [Metric `db.lock.waits`](#metric-dblockwaits)
 - [Resource Usage Metrics](#resource-usage-metrics)
   - [Metric `db.disk.usage`](#metric-dbdiskusage)
   - [Metric `db.disk.utilization`](#metric-dbdiskutilization)
@@ -260,6 +268,91 @@ This metric is [optional](https://github.com/open-telemetry/semantic-conventions
 | Name                     | Instrument Type | Units (UCUM)     | Description                                                                                  |
 |--------------------------|-----------------|------------------|----------------------------------------------------------------------------------------------|
 | `db.overflow.user.count` | UpDownCounter   | `{overflowUser}` | Number of times a User thread attempted to acquire a lock when no locks were available.      |
+
+### Metric: `db.chunk.reads`
+This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
+
+| Name             | Instrument Type | Units (UCUM)   | Description                                            |
+|------------------|-----------------|----------------|--------------------------------------------------------|
+| `db.chunk.reads` | UpDownCounter   | `{chunkReads}` | Information about the number of disk reads  per chunk. |
+
+| Attribute         | Type   | Description   | Example   | Requirement Level |
+|-------------------|--------|---------------|-----------|-------------------|
+| `db.chunk.number` | string | Chunk Number. | `1` ; `2` | Required          |
+
+### Metric: `db.chunk.writes`
+This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
+
+| Name              | Instrument Type | Units (UCUM)    | Description                                            |
+|-------------------|-----------------|-----------------|--------------------------------------------------------|
+| `db.chunk.writes` | UpDownCounter   | `{chunkWrites}` | Information about the number of disk writes per chunk. |
+
+| Attribute         | Type   | Description   | Example   | Requirement Level |
+|-------------------|--------|---------------|-----------|-------------------|
+| `db.chunk.number` | string | Chunk Number. | `1` ; `2` | Required          |
+
+### Metric: `db.chunk.pages.read`
+This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
+
+| Name                  | Instrument Type | Units (UCUM)       | Description                                           |
+|-----------------------|-----------------|--------------------|-------------------------------------------------------|
+| `db.chunk.pages.read` | UpDownCounter   | `{chunkPagesRead}` | Information about the number of page reads per chunk. |
+
+| Attribute         | Type   | Description   | Example   | Requirement Level |
+|-------------------|--------|---------------|-----------|-------------------|
+| `db.chunk.number` | string | Chunk Number. | `1` ; `2` | Required          |
+
+### Metric: `db.chunk.pages.write`
+This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
+
+| Name                   | Instrument Type | Units (UCUM)        | Description                                            |
+|------------------------|-----------------|---------------------|--------------------------------------------------------|
+| `db.chunk.pages.write` | UpDownCounter   | `{chunkPagesWrite}` | Information about the number of page writes per chunk. |
+
+| Attribute         | Type   | Description   | Example   | Requirement Level |
+|-------------------|--------|---------------|-----------|-------------------|
+| `db.chunk.number` | string | Chunk Number. | `1` ; `2` | Required          |
+
+### Metric: `db.memory.segment.size`
+This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
+
+| Name                     | Instrument Type | Units (UCUM)          | Description                 |
+|--------------------------|-----------------|-----------------------|-----------------------------|
+| `db.memory.segment.size` | UpDownCounter   | `{memorySegmentSize}` | Size of the Memory Segment. |
+
+| Attribute          | Type   | Description    | Example   | Requirement Level |
+|--------------------|--------|----------------|-----------|-------------------|
+| `db.segment.class` | string | Segment Class. | `1` ; `2` | Required          |
+
+### Metric: `db.memory.segment.bulk.used`
+This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
+
+| Name                           | Instrument Type  | Units (UCUM)                    | Description                    |
+|--------------------------------|------------------|---------------------------------|--------------------------------|
+| `db.memory.segment.bulk.used`  | UpDownCounter    | `{memorySegmentBulkUsed}`       | Size of the Segment Bulk used. |
+
+| Attribute          | Type   | Description    | Example   | Requirement Level |
+|--------------------|--------|----------------|-----------|-------------------|
+| `db.segment.class` | string | Segment Class. | `1` ; `2` | Required          |
+
+### Metric: `db.memory.segment.bulk.free`
+This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
+
+| Name                           | Instrument Type  | Units (UCUM)              | Description                         |
+|--------------------------------|------------------|---------------------------|-------------------------------------|
+| `db.memory.segment.bulk.free`  | UpDownCounter    | `{memorySegmentBulkFree}` | Size of the Segment Bulk available. |
+
+| Attribute          | Type   | Description    | Example   | Requirement Level |
+|--------------------|--------|----------------|-----------|-------------------|
+| `db.segment.class` | string | Segment Class. | `1` ; `2` | Required          |
+
+### Metric: `db.lock.waits`
+This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
+
+| Name              | Instrument Type | Units (UCUM)  | Description                         |
+|-------------------|-----------------|---------------|-------------------------------------|
+| `db.lock.waits`   | UpDownCounter   | `{lockWaits}` | Number of threads waiting for lock. |
+
 
 ## Resource Usage Metrics
 ### Metric: `db.disk.usage`

--- a/docs/semconv/database.md
+++ b/docs/semconv/database.md
@@ -40,14 +40,10 @@ This page tries to describe a semantic convention for the attributes and metrics
   - [Metric `db.overflow.lock.count`](#metric-dboverflowlockcount)
   - [Metric `db.overflow.transaction.count`](#metric-dboverflowtransactioncount)
   - [Metric `db.overflow.user.count`](#metric-dboverflowusercount)
-  - [Metric `db.chunk.reads`](#metric-dbchunkreads)
-  - [Metric `db.chunk.writes`](#metric-dbchunkwrites)
-  - [Metric `db.chunk.pages.read`](#metric-dbchunkpagesread)
-  - [Metric `db.chunk.pages.read`](#metric-dbchunkpageswrite)
-  - [Metric `db.memory.segment.size`](#metric-dbmemorysegmentsize)
-  - [Metric `db.memory.segment.bulk.used`](#metric-dbmemorysegmentbulkused)
-  - [Metric `db.memory.segment.bulk.free`](#metric-dbmemorysegmentbulkfree)
   - [Metric `db.lock.waits`](#metric-dblockwaits)
+  - [Metric `db.cache.read.ratio`](#metric-dbcachereadratio)
+  - [Metric `db.cache.write.ratio`](#metric-dbcachewriteratio)
+  - [Metric `db.lru.writes`](#metric-dblruwrites)
 - [Resource Usage Metrics](#resource-usage-metrics)
   - [Metric `db.disk.usage`](#metric-dbdiskusage)
   - [Metric `db.disk.utilization`](#metric-dbdiskutilization)
@@ -269,82 +265,20 @@ This metric is [optional](https://github.com/open-telemetry/semantic-conventions
 |--------------------------|-----------------|------------------|----------------------------------------------------------------------------------------------|
 | `db.overflow.user.count` | UpDownCounter   | `{overflowUser}` | Number of times a User thread attempted to acquire a lock when no locks were available.      |
 
-### Metric: `db.chunk.reads`
+### Metric: `db.cache.read.ratio`
 This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
 
-| Name             | Instrument Type | Units (UCUM)   | Description                                            |
-|------------------|-----------------|----------------|--------------------------------------------------------|
-| `db.chunk.reads` | UpDownCounter   | `{chunkReads}` | Information about the number of disk reads  per chunk. |
+| Name                  | Instrument Type   | Units (UCUM)       | Description                                                                              |
+|-----------------------|-------------------|--------------------|------------------------------------------------------------------------------------------|
+| `db.cache.read.ratio` | UpDownCounter     | `{cacheReadRatio}` | Percentage of page reads for this buffer pool that were satisfied by a cached page image |
 
-| Attribute         | Type   | Description   | Example   | Requirement Level |
-|-------------------|--------|---------------|-----------|-------------------|
-| `db.chunk.number` | string | Chunk Number. | `1` ; `2` | Required          |
 
-### Metric: `db.chunk.writes`
+## Metric: `db.cache.write.ratio`
 This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
 
-| Name              | Instrument Type | Units (UCUM)    | Description                                            |
-|-------------------|-----------------|-----------------|--------------------------------------------------------|
-| `db.chunk.writes` | UpDownCounter   | `{chunkWrites}` | Information about the number of disk writes per chunk. |
-
-| Attribute         | Type   | Description   | Example   | Requirement Level |
-|-------------------|--------|---------------|-----------|-------------------|
-| `db.chunk.number` | string | Chunk Number. | `1` ; `2` | Required          |
-
-### Metric: `db.chunk.pages.read`
-This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
-
-| Name                  | Instrument Type | Units (UCUM)       | Description                                           |
-|-----------------------|-----------------|--------------------|-------------------------------------------------------|
-| `db.chunk.pages.read` | UpDownCounter   | `{chunkPagesRead}` | Information about the number of page reads per chunk. |
-
-| Attribute         | Type   | Description   | Example   | Requirement Level |
-|-------------------|--------|---------------|-----------|-------------------|
-| `db.chunk.number` | string | Chunk Number. | `1` ; `2` | Required          |
-
-### Metric: `db.chunk.pages.write`
-This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
-
-| Name                   | Instrument Type | Units (UCUM)        | Description                                            |
-|------------------------|-----------------|---------------------|--------------------------------------------------------|
-| `db.chunk.pages.write` | UpDownCounter   | `{chunkPagesWrite}` | Information about the number of page writes per chunk. |
-
-| Attribute         | Type   | Description   | Example   | Requirement Level |
-|-------------------|--------|---------------|-----------|-------------------|
-| `db.chunk.number` | string | Chunk Number. | `1` ; `2` | Required          |
-
-### Metric: `db.memory.segment.size`
-This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
-
-| Name                     | Instrument Type | Units (UCUM)          | Description                 |
-|--------------------------|-----------------|-----------------------|-----------------------------|
-| `db.memory.segment.size` | UpDownCounter   | `{memorySegmentSize}` | Size of the Memory Segment. |
-
-| Attribute          | Type   | Description    | Example   | Requirement Level |
-|--------------------|--------|----------------|-----------|-------------------|
-| `db.segment.class` | string | Segment Class. | `1` ; `2` | Required          |
-
-### Metric: `db.memory.segment.bulk.used`
-This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
-
-| Name                           | Instrument Type  | Units (UCUM)                    | Description                    |
-|--------------------------------|------------------|---------------------------------|--------------------------------|
-| `db.memory.segment.bulk.used`  | UpDownCounter    | `{memorySegmentBulkUsed}`       | Size of the Segment Bulk used. |
-
-| Attribute          | Type   | Description    | Example   | Requirement Level |
-|--------------------|--------|----------------|-----------|-------------------|
-| `db.segment.class` | string | Segment Class. | `1` ; `2` | Required          |
-
-### Metric: `db.memory.segment.bulk.free`
-This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
-
-| Name                           | Instrument Type  | Units (UCUM)              | Description                         |
-|--------------------------------|------------------|---------------------------|-------------------------------------|
-| `db.memory.segment.bulk.free`  | UpDownCounter    | `{memorySegmentBulkFree}` | Size of the Segment Bulk available. |
-
-| Attribute          | Type   | Description    | Example   | Requirement Level |
-|--------------------|--------|----------------|-----------|-------------------|
-| `db.segment.class` | string | Segment Class. | `1` ; `2` | Required          |
+| Name                   | Instrument Type   | Units (UCUM)        | Description                                                                               |
+|------------------------|-------------------|---------------------|-------------------------------------------------------------------------------------------|
+| `db.cache.write.ratio` | UpDownCounter     | `{cacheWriteRatio}` | Percentage of page Writes for this buffer pool that were satisfied by a cached page image |
 
 ### Metric: `db.lock.waits`
 This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
@@ -353,6 +287,13 @@ This metric is [optional](https://github.com/open-telemetry/semantic-conventions
 |-------------------|-----------------|---------------|-------------------------------------|
 | `db.lock.waits`   | UpDownCounter   | `{lockWaits}` | Number of threads waiting for lock. |
 
+
+### Metric: `db.lru.writes`
+This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
+
+| Name            | Instrument Type | Units (UCUM)  | Description           |
+|-----------------|-----------------|---------------|-----------------------|
+| `db.lru.writes` | UpDownCounter   | `{lruWrites}` | Number of LRU Writes. |
 
 ## Resource Usage Metrics
 ### Metric: `db.disk.usage`

--- a/docs/semconv/database.md
+++ b/docs/semconv/database.md
@@ -265,21 +265,6 @@ This metric is [optional](https://github.com/open-telemetry/semantic-conventions
 |--------------------------|-----------------|------------------|----------------------------------------------------------------------------------------------|
 | `db.overflow.user.count` | UpDownCounter   | `{overflowUser}` | Number of times a User thread attempted to acquire a lock when no locks were available.      |
 
-### Metric: `db.cache.read.ratio`
-This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
-
-| Name                  | Instrument Type   | Units (UCUM)       | Description                                                                              |
-|-----------------------|-------------------|--------------------|------------------------------------------------------------------------------------------|
-| `db.cache.read.ratio` | UpDownCounter     | `{cacheReadRatio}` | Percentage of page reads for this buffer pool that were satisfied by a cached page image |
-
-
-## Metric: `db.cache.write.ratio`
-This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
-
-| Name                   | Instrument Type   | Units (UCUM)        | Description                                                                               |
-|------------------------|-------------------|---------------------|-------------------------------------------------------------------------------------------|
-| `db.cache.write.ratio` | UpDownCounter     | `{cacheWriteRatio}` | Percentage of page Writes for this buffer pool that were satisfied by a cached page image |
-
 ### Metric: `db.lock.waits`
 This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
 
@@ -287,13 +272,31 @@ This metric is [optional](https://github.com/open-telemetry/semantic-conventions
 |-------------------|-----------------|---------------|-------------------------------------|
 | `db.lock.waits`   | UpDownCounter   | `{lockWaits}` | Number of threads waiting for lock. |
 
+### Metric: `db.cache.read.ratio`
+This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
+
+| Name                  | Instrument Type | Units (UCUM) | Description                                                                              |
+|-----------------------|-----------------|--------------|------------------------------------------------------------------------------------------|
+| `db.cache.read.ratio` | Gauge           | `1`          | Percentage of page reads for this buffer pool that were satisfied by a cached page image |
+
+
+### Metric: `db.cache.write.ratio`
+This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
+
+| Name                   | Instrument Type | Units (UCUM) | Description                                                                               |
+|------------------------|-----------------|--------------|-------------------------------------------------------------------------------------------|
+| `db.cache.write.ratio` | Gauge           | `1`          | Percentage of page Writes for this buffer pool that were satisfied by a cached page image |
 
 ### Metric: `db.lru.writes`
 This metric is [optional](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metric-requirement-level.md#opt-in).
 
-| Name            | Instrument Type | Units (UCUM)  | Description           |
-|-----------------|-----------------|---------------|-----------------------|
-| `db.lru.writes` | UpDownCounter   | `{lruWrites}` | Number of LRU Writes. |
+| Name            | Instrument Type | Units (UCUM)  | Description                            |
+|-----------------|-----------------|---------------|----------------------------------------|
+| `db.lru.writes` | UpDownCounter   | `{lruWrites}` | Number of Least Recently Used  Writes. |
+
+### Notes:
+
+- The database server performs LRU (Least Recently Used) writes as background writes that typically occur when the percentage of dirty buffers (pages that are not accessed) exceeds the percent that is specified for lru_max_dirty in the BUFFERPOOL configuration parameter.
 
 ## Resource Usage Metrics
 ### Metric: `db.disk.usage`


### PR DESCRIPTION
As a part of the release 4 of informix DB sensor Roadmap, the following metrics are added. The semantic conventions for the same are added in this PR.

- db.lock.waits(KPI) :Number of threads waiting for lock.
- db.cache.read.ratio(KPI): Percentage of page reads for this buffer pool that were satisfied by a cached page image
- db.cache.write.ratio (KPI):Percentage of page writes for this buffer pool that were satisfied by a cached page image
- db.lru.writes(KPI): Number of LRU writes performed