### PR TITLE
Fix the package issue for mq appliance dc

### DIFF
--- a/host/README.md
+++ b/host/README.md
@@ -17,7 +17,7 @@ Download the latest  [Release package](https://github.com/instana/otel-dc/releas
 
 1) Download the installation package:
 ```bash
-wget https://github.com/instana/otel-dc/releases/download/v1.0.3/otel-dc-host-0.2.3.tar
+wget https://github.com/instana/otel-dc/releases/download/v1.0.2/otel-dc-host-0.2.3.tar
 ```
 
 2) Extract the package to the desired deployment location:

--- a/host/README.md
+++ b/host/README.md
@@ -17,13 +17,13 @@ Download the latest  [Release package](https://github.com/instana/otel-dc/releas
 
 1) Download the installation package:
 ```bash
-wget https://github.com/instana/otel-dc/releases/download/v1.0.1/otel-dc-host-0.2.2.tar
+wget https://github.com/instana/otel-dc/releases/download/v1.0.3/otel-dc-host-0.2.3.tar
 ```
 
 2) Extract the package to the desired deployment location:
 ```bash
-tar vxf otel-dc-host-0.2.2.tar
-cd otel-dc-host-0.2.2
+tar vxf otel-dc-host-0.2.3.tar
+cd otel-dc-host-0.2.3
 ```
 
 3) Make sure following configuration files are correct for your environment:

--- a/host/README.md
+++ b/host/README.md
@@ -17,7 +17,7 @@ Download the latest  [Release package](https://github.com/instana/otel-dc/releas
 
 1) Download the installation package:
 ```bash
-wget https://github.com/instana/otel-dc/releases/download/v1.0.2/otel-dc-host-0.2.3.tar
+wget https://github.com/instana/otel-dc/releases/download/v1.0.3/otel-dc-host-0.2.3.tar
 ```
 
 2) Extract the package to the desired deployment location:

--- a/host/build.gradle
+++ b/host/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.instana.dc"
-version = "0.2.2"
+version = "0.2.3"
 
 repositories {
     mavenCentral()
@@ -34,6 +34,10 @@ application {
 
 applicationDistribution.from("config") {
     into "config"
+}
+
+applicationDistribution.from("scripts") {
+    into "scripts"
 }
 
 test {

--- a/host/config/config-mqappliance.yaml
+++ b/host/config/config-mqappliance.yaml
@@ -6,8 +6,8 @@ instances:
     appliance.password: xxxxxxxx
 
     #Data collector properties:
-    poll.interval: 10
-    callback.interval: 5
+    poll.interval: 25
+    callback.interval: 30
     otel.backend.url: http://127.0.0.1:4317
     #otel.backend.using.http: true
     #otel.backend.url: http://127.0.0.1:4318/v1/metrics

--- a/rdb/README.md
+++ b/rdb/README.md
@@ -17,7 +17,7 @@ Download the latest  [Release package](https://github.com/instana/otel-dc/releas
 
 1) Download the installation package:
 ```bash
-wget https://github.com/instana/otel-dc/releases/download/v1.0.1/otel-dc-rdb-0.5.4.tar
+wget https://github.com/instana/otel-dc/releases/download/v1.0.3/otel-dc-rdb-0.5.4.tar
 ```
 
 2) Extract the package to the desired deployment location:

--- a/rdb/README.md
+++ b/rdb/README.md
@@ -17,7 +17,7 @@ Download the latest  [Release package](https://github.com/instana/otel-dc/releas
 
 1) Download the installation package:
 ```bash
-wget https://github.com/instana/otel-dc/releases/download/v1.0.2/otel-dc-rdb-0.5.4.tar
+wget https://github.com/instana/otel-dc/releases/download/v1.0.3/otel-dc-rdb-0.5.4.tar
 ```
 
 2) Extract the package to the desired deployment location:

--- a/rdb/README.md
+++ b/rdb/README.md
@@ -17,7 +17,7 @@ Download the latest  [Release package](https://github.com/instana/otel-dc/releas
 
 1) Download the installation package:
 ```bash
-wget https://github.com/instana/otel-dc/releases/download/v1.0.3/otel-dc-rdb-0.5.4.tar
+wget https://github.com/instana/otel-dc/releases/download/v1.0.2/otel-dc-rdb-0.5.4.tar
 ```
 
 2) Extract the package to the desired deployment location:


### PR DESCRIPTION
Include the script for collecting data from MQ appliance data to the package of otel-host-dc.
```
applicationDistribution.from("scripts") {
    into "scripts"
}
```