### PR TITLE
Add otel.backend.using.http option in config file

### DIFF
--- a/llm/config/config.yaml
+++ b/llm/config/config.yaml
@@ -3,6 +3,7 @@ llm.application: LLM_DC
 instances:
   - otel.agentless.mode: true
     otel.backend.url: http://<backend/agent-otlp-acceptor>:4317
+    otel.backend.using.http: false
     callback.interval: 10
     otel.service.name: DC1
     otel.service.port: 8000


### PR DESCRIPTION
If OTel DC needs to connect the `4318(otlp-http)` port of backend/agent, the `otel.backend.using.http` should be true.