### PR TITLE
fix: update protobuf-java and netty-handler to fix CVE-2024-7254 and CVE-2025-24970

### DIFF
--- a/llm/build.gradle
+++ b/llm/build.gradle
@@ -23,10 +23,14 @@ dependencies {
     implementation("io.opentelemetry.proto:opentelemetry-proto:1.0.0-alpha")
     implementation("io.opentelemetry.semconv:opentelemetry-semconv:1.23.1-alpha")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.0-rc1")
-    implementation("com.google.protobuf:protobuf-java:3.23.4")
-    implementation("com.google.protobuf:protobuf-java-util:3.23.4")
-    implementation("com.linecorp.armeria:armeria:1.27.3")
-    implementation("com.linecorp.armeria:armeria-grpc:1.27.3")
+    implementation("com.google.protobuf:protobuf-java:4.28.2")
+    implementation("com.google.protobuf:protobuf-java-util:4.28.2")
+    implementation("com.linecorp.armeria:armeria:1.29.4")
+    constraints {
+      implementation("io.netty:netty-handler:4.1.118+") // because 4.1.110 from com.linecorp.armeria:armeria:1.29.4 has CVE-2025-24970
+      implementation("io.netty:netty-handler-proxy:4.1.118+") // because 4.1.110 from com.linecorp.armeria:armeria:1.29.4 has CVE-2025-24970
+    }
+    implementation("com.linecorp.armeria:armeria-grpc:1.29.4")
     implementation(files("libs/otel-dc-0.10.0.jar"))
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")


### PR DESCRIPTION
The resulting versions are these:
```
$ tar -tvf ./build/distributions/otel-dc-llm-1.0.5.tar | grep -e protobuf-java -e netty-handler
-rw-rw-r-- 0/0           75564 2025-02-21 11:53 otel-dc-llm-1.0.5/lib/protobuf-java-util-4.28.2.jar
-rw-rw-r-- 0/0         1840061 2025-02-21 11:53 otel-dc-llm-1.0.5/lib/protobuf-java-4.28.2.jar
-rw-rw-r-- 0/0           25650 2025-02-21 14:59 otel-dc-llm-1.0.5/lib/netty-handler-proxy-4.1.118.Final.jar
-rw-rw-r-- 0/0          580162 2025-02-21 13:43 otel-dc-llm-1.0.5/lib/netty-handler-4.1.118.Final.jar
```