### PR TITLE
fix: update protobuf-java to fix CVE-2024-7254

### DIFF
--- a/llm/build.gradle
+++ b/llm/build.gradle
@@ -23,12 +23,12 @@ dependencies {
     implementation("io.opentelemetry.proto:opentelemetry-proto:1.0.0-alpha")
     implementation("io.opentelemetry.semconv:opentelemetry-semconv:1.23.1-alpha")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.0-rc1")
-    implementation("com.google.protobuf:protobuf-java:4.28.2")
-    implementation("com.google.protobuf:protobuf-java-util:4.28.2")
+    implementation("com.google.protobuf:protobuf-java:3.25.6")
+    implementation("com.google.protobuf:protobuf-java-util:3.25.6")
     implementation("com.linecorp.armeria:armeria:1.29.4")
     constraints {
-      implementation("io.netty:netty-handler:4.1.118+") // because 4.1.110 from com.linecorp.armeria:armeria:1.29.4 has CVE-2025-24970
-      implementation("io.netty:netty-handler-proxy:4.1.118+") // because 4.1.110 from com.linecorp.armeria:armeria:1.29.4 has CVE-2025-24970
+        implementation("io.netty:netty-handler:4.1.118+") // because 4.1.110 from com.linecorp.armeria:armeria:1.29.4 has CVE-2025-24970
+        implementation("io.netty:netty-handler-proxy:4.1.118+") // because 4.1.110 from com.linecorp.armeria:armeria:1.29.4 has CVE-2025-24970
     }
     implementation("com.linecorp.armeria:armeria-grpc:1.29.4")
     implementation(files("libs/otel-dc-0.10.0.jar"))


### PR DESCRIPTION
com.google.protobuf:protobuf-java-util was upgraded to 4.28.2 to fix CVE-2024-7254. This version breaks the data collector with the following error. The dependency has been downgraded to 3.25.6, the latest version that does not contain the vulnerability and that works well with the data collector.

> Exception in thread "main" java.lang.IllegalAccessError: class org.curioswitch.common.protobuf.json.ProtobufUtil tried to access method 'boolean com.google.protobuf.Descriptors$FieldDescriptor.hasOptionalKeyword()' (org.curioswitch.common.protobuf.json.ProtobufUtil and com.google.protobuf.Descriptors$FieldDescriptor are in unnamed module of loader 'app')
	at org.curioswitch.common.protobuf.json.ProtobufUtil.hasOptionalKeyword(ProtobufUtil.java:306)
	at org.curioswitch.common.protobuf.json.DoWrite.checkDefaultValue(DoWrite.java:490)
	at org.curioswitch.common.protobuf.json.DoWrite.apply(DoWrite.java:352)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod$WithBody.applyCode(TypeWriter.java:730)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod$WithBody.applyBody(TypeWriter.java:715)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod.apply(TypeWriter.java:622)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$AccessBridgeWrapper.apply(TypeWriter.java:1293)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default$ForCreation.create(TypeWriter.java:6043)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default.make(TypeWriter.java:2224)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$UsingTypeWriter.make(DynamicType.java:4050)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase.make(DynamicType.java:3734)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$Delegator.make(DynamicType.java:3986)
	at org.curioswitch.common.protobuf.json.TypeSpecificMarshaller.buildOrFindMarshaller(TypeSpecificMarshaller.java:269)
	at org.curioswitch.common.protobuf.json.TypeSpecificMarshaller.buildAndAdd(TypeSpecificMarshaller.java:146)
	at org.curioswitch.common.protobuf.json.MessageMarshaller$Builder.build(MessageMarshaller.java:494)
	at com.linecorp.armeria.server.grpc.JsonUnframedGrpcErrorHandler.<clinit>(JsonUnframedGrpcErrorHandler.java:85)
	at com.linecorp.armeria.server.grpc.UnframedGrpcErrorHandler.ofJson(UnframedGrpcErrorHandler.java:65)
	at com.linecorp.armeria.server.grpc.HttpJsonTranscodingOptionsBuilder.<init>(HttpJsonTranscodingOptionsBuilder.java:44)
	at com.linecorp.armeria.server.grpc.HttpJsonTranscodingOptions.builder(HttpJsonTranscodingOptions.java:35)
	at com.linecorp.armeria.server.grpc.DefaultHttpJsonTranscodingOptions.<clinit>(DefaultHttpJsonTranscodingOptions.java:26)
	at com.linecorp.armeria.server.grpc.HttpJsonTranscodingOptions.of(HttpJsonTranscodingOptions.java:42)
	at com.linecorp.armeria.server.grpc.GrpcServiceBuilder.<init>(GrpcServiceBuilder.java:129)
	at com.linecorp.armeria.server.grpc.GrpcService.builder(GrpcService.java:56)
	at com.instana.dc.llm.impl.llm.LLMDc.initOnce(LLMDc.java:162)
	at com.instana.dc.llm.DataCollector.<init>(DataCollector.java:47)
	at com.instana.dc.llm.DataCollector.main(DataCollector.java:58)